### PR TITLE
export and show AWS_ACCOUNT_NAME and AWS_ASSUMED_ROLE

### DIFF
--- a/README_developers.rst
+++ b/README_developers.rst
@@ -1,0 +1,12 @@
+
+To see test errors after a test:
+
+.. code-block:: console
+
+    pyb clean run_unit_tests || cat target/reports/TEST*xml
+
+and
+
+.. code-block:: console
+
+    pyb run_cram_tests || less /home/robert/ss/afp-cli/target/reports/cram.err

--- a/src/cmdlinetest/afp_mock.py
+++ b/src/cmdlinetest/afp_mock.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
+import bottle
 from bottle import route
 from textwrap import dedent
 from bottledaemon import daemon_run
+import sys
 
 """ Simple AFP mock to allow testing the afp-cli. """
 
@@ -21,4 +23,8 @@ def credentials(account, role):
                    "Expiration": "2032-01-01T00:00:00Z",
                    "Type": "AWS-HMAC"}""").strip()
 
-daemon_run(host='localhost', port=5555)
+if len(sys.argv) > 1:
+    daemon_run(host='localhost', port=5555)
+else:
+    # manual testing mode on different port, so it won't stop "pyb install" from running tests
+    bottle.run(host='localhost', port=5544)

--- a/src/cmdlinetest/test_afp_cli.t
+++ b/src/cmdlinetest/test_afp_cli.t
@@ -85,10 +85,10 @@
 
 # Test credentials with subshell
 
-#  $ afp --no-ask-pw --api-url=http://localhost:5555 test_account test_role
-#  Entering AFP subshell for account test_account, role test_role.
-#  Press CTRL+D to exit.
-#  Left AFP subshell.
+  $ afp --no-ask-pw --api-url=http://localhost:5555 test_account test_role < /dev/null
+  Entering AFP subshell for account test_account, role test_role.
+  Press CTRL+D to exit.
+  Left AFP subshell.
 
 
 # Test credentials with show

--- a/src/cmdlinetest/test_afp_cli.t
+++ b/src/cmdlinetest/test_afp_cli.t
@@ -95,6 +95,8 @@
 
   $ afp --no-ask-pw --api-url=http://localhost:5555 --show test_account test_role
   AWS_ACCESS_KEY_ID='XXXXXXXXXXXX'
+  AWS_ACCOUNT_NAME='test_account'
+  AWS_ASSUMED_ROLE='test_role'
   AWS_EXPIRATION_DATE='2032-01-01T00:00:00Z'
   AWS_SECRET_ACCESS_KEY='XXXXXXXXXXXX'
   AWS_SECURITY_TOKEN='XXXXXXXXXXXX'
@@ -105,6 +107,8 @@
 
   $ afp --no-ask-pw --api-url=http://localhost:5555 --show test_account
   AWS_ACCESS_KEY_ID='XXXXXXXXXXXX'
+  AWS_ACCOUNT_NAME='test_account'
+  AWS_ASSUMED_ROLE='test_role'
   AWS_EXPIRATION_DATE='2032-01-01T00:00:00Z'
   AWS_SECRET_ACCESS_KEY='XXXXXXXXXXXX'
   AWS_SECURITY_TOKEN='XXXXXXXXXXXX'
@@ -115,6 +119,8 @@
 
   $ afp --no-ask-pw --api-url=http://localhost:5555 --export test_account test_role
   export AWS_ACCESS_KEY_ID='XXXXXXXXXXXX'
+  export AWS_ACCOUNT_NAME='test_account'
+  export AWS_ASSUMED_ROLE='test_role'
   export AWS_EXPIRATION_DATE='2032-01-01T00:00:00Z'
   export AWS_SECRET_ACCESS_KEY='XXXXXXXXXXXX'
   export AWS_SECURITY_TOKEN='XXXXXXXXXXXX'

--- a/src/main/python/afp_cli/__init__.py
+++ b/src/main/python/afp_cli/__init__.py
@@ -2,6 +2,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, unicode_literals, division
 
-from .client import AWSFederationClientCmd, print_aws_credentials
+from .client import AWSFederationClientCmd
 
-__all__ = ['AWSFederationClientCmd', 'print_aws_credentials']
+__all__ = ['AWSFederationClientCmd']

--- a/src/main/python/afp_cli/cli.py
+++ b/src/main/python/afp_cli/cli.py
@@ -19,6 +19,7 @@ Options:
 """
 
 from __future__ import print_function, absolute_import, division
+from datetime import datetime
 import getpass
 import os
 import random
@@ -153,7 +154,8 @@ def get_aws_credentials(federation_client, account, role):
     except Exception as exc:
         error("Failed to get credentials from AWS: %s" % exc)
 
-    aws_credentials['AWS_VALID_SECONDS'] = cli.get_valid_seconds(aws_credentials['AWS_EXPIRATION_DATE'])
+    aws_credentials['AWS_VALID_SECONDS'] = cli.get_valid_seconds(aws_credentials['AWS_EXPIRATION_DATE'],
+                                                                 datetime.utcnow())
     aws_credentials['AWS_ACCOUNT_NAME'] = account
     aws_credentials['AWS_ASSUMED_ROLE'] = role
     return aws_credentials

--- a/src/main/python/afp_cli/cli.py
+++ b/src/main/python/afp_cli/cli.py
@@ -20,18 +20,17 @@ Options:
 
 from __future__ import print_function, absolute_import, division
 import getpass
+import os
 import random
 import socket
 import subprocess
 import sys
 import tempfile
-
-import os
 import yamlreader
+
 from docopt import docopt
 from afp_cli import AWSFederationClientCmd, aws_credentials_file
 import afp_cli.cli_functions as cli
-
 
 CFGDIR = '/etc/afp-cli'
 DEBUG = False

--- a/src/main/python/afp_cli/cli.py
+++ b/src/main/python/afp_cli/cli.py
@@ -20,17 +20,17 @@ Options:
 
 from __future__ import print_function, absolute_import, division
 import getpass
-import os
 import random
 import socket
 import subprocess
 import sys
 import tempfile
-import yamlreader
+from datetime import datetime
 
+import os
+import yamlreader
 from docopt import docopt
-from datetime import datetime, timedelta
-from afp_cli import AWSFederationClientCmd, print_aws_credentials, aws_credentials_file
+from afp_cli import AWSFederationClientCmd, aws_credentials_file
 
 CFGDIR = '/etc/afp-cli'
 DEBUG = False
@@ -44,11 +44,6 @@ def error(message):
 def debug(message):
     if DEBUG:
         print(message)
-
-
-def get_user(username):
-    """Check if we have a given user, else take the current one"""
-    return username or getpass.getuser()
 
 
 def get_password(username):
@@ -106,27 +101,19 @@ function afp_minutes_left {{
 }}
 
 PS1="(AWS {account}/{role} \\$(afp_minutes_left)) $PS1"
-export AWS_ACCESS_KEY_ID={AWS_ACCESS_KEY_ID}
-export AWS_SECRET_ACCESS_KEY={AWS_SECRET_ACCESS_KEY}
-export AWS_SESSION_TOKEN={AWS_SESSION_TOKEN}
-export AWS_SECURITY_TOKEN={AWS_SECURITY_TOKEN}
 """
 
 BATCH_FILE_TEMPLATE = """
 @echo off
 set PROMPT=$C AWS {account}/{role} $F
-
-set AWS_ACCESS_KEY_ID={AWS_ACCESS_KEY_ID}
-set AWS_SECRET_ACCESS_KEY={AWS_SECRET_ACCESS_KEY}
-set AWS_SESSION_TOKEN={AWS_SESSION_TOKEN}
-set AWS_SECURITY_TOKEN={AWS_SECURITY_TOKEN}
 """
 
 
 def start_subshell(aws_credentials, role, account):
     print("Press CTRL+D to exit.")
     rc_script = tempfile.NamedTemporaryFile(mode='w')
-    rc_script.write(RC_SCRIPT_TEMPLATE.format(role=role, account=account, **aws_credentials))
+    rc_script.write(RC_SCRIPT_TEMPLATE.format(role=role, account=account))
+    rc_script.write(format_aws_credentials(aws_credentials, prefix='export '))
     rc_script.flush()
     subprocess.call(
         ["bash", "--rcfile", rc_script.name],
@@ -136,7 +123,8 @@ def start_subshell(aws_credentials, role, account):
 
 def start_subcmd(aws_credentials, role, account):
     batch_file = tempfile.NamedTemporaryFile(suffix=".bat", delete=False)
-    batch_file.write(BATCH_FILE_TEMPLATE.format(role=role, account=account, **aws_credentials))
+    batch_file.write(BATCH_FILE_TEMPLATE.format(role=role, account=account))
+    batch_file.write(format_aws_credentials(aws_credentials, prefix='set '))
     batch_file.flush()
     batch_file.close()
     subprocess.call(
@@ -161,27 +149,34 @@ def get_role(arguments, federation_client, account):
             error("Could not find any role for account %s" % account)
 
 
+def get_valid_seconds(aws_expiration_date, utcnow=datetime.utcnow()):
+    try:
+        credentials_valid_until = datetime.strptime(aws_expiration_date, "%Y-%m-%dT%H:%M:%SZ", )
+        return (credentials_valid_until - utcnow).seconds
+    except Exception:
+        default_seconds = 3600
+        msg = "Failed to parse expiration date '{0}' for AWS credentials, assuming {1} seconds.".format(
+            aws_expiration_date, default_seconds)
+        print(msg, file=sys.stderr)
+        return default_seconds
+
+
 def get_aws_credentials(federation_client, account, role):
     try:
         aws_credentials = federation_client.get_aws_credentials(account, role)
     except Exception as exc:
         error("Failed to get credentials from AWS: %s" % exc)
 
-    try:
-        credentials_valid_until = datetime.strptime(
-            aws_credentials['AWS_EXPIRATION_DATE'],
-            "%Y-%m-%dT%H:%M:%SZ",)
-    except Exception:
-        default_seconds = 3600
-        msg = ("Failed to parse expiration date '{0}' for "
-               "AWS credentials, assuming {1} seconds.").format(
-            aws_credentials['AWS_EXPIRATION_DATE'], default_seconds)
-        print(msg, file=sys.stderr)
-        credentials_valid_until = (datetime.utcnow() +
-                                   timedelta(seconds=default_seconds))
-    valid_seconds = (credentials_valid_until - datetime.utcnow()).seconds
-    aws_credentials['AWS_VALID_SECONDS'] = valid_seconds
+    aws_credentials['AWS_VALID_SECONDS'] = get_valid_seconds(aws_credentials['AWS_EXPIRATION_DATE'])
+    aws_credentials['AWS_ACCOUNT_NAME'] = account
+    aws_credentials['AWS_ASSUMED_ROLE'] = role
     return aws_credentials
+
+
+def format_aws_credentials(credentials, prefix=''):
+    """Format aws credentials with optional prefix"""
+    return os.linesep.join(["{0}{1}='{2}'".format(prefix, key, value)
+                            for (key, value) in sorted(credentials.items())])
 
 
 def main():
@@ -200,7 +195,7 @@ def main():
     api_url = arguments['--api-url'] or config.get('api_url')
     if api_url is None:
         api_url = 'https://{fqdn}/afp-api/latest'.format(fqdn=get_default_afp_server())
-    username = get_user(arguments['--user'] or config.get("user"))
+    username = arguments['--user'] or config.get("user") or getpass.getuser()
     password = 'PASSWORD' if arguments['--no-ask-pw'] else get_password(username)
     federation_client = AWSFederationClientCmd(api_url=api_url,
                                                username=username,
@@ -211,13 +206,13 @@ def main():
         aws_credentials = get_aws_credentials(federation_client, account, role)
 
         if arguments['--show']:
-            print_aws_credentials(aws_credentials)
+            print(format_aws_credentials(aws_credentials))
 
         elif arguments['--export']:
             if os.name == "nt":
-                print_aws_credentials(aws_credentials, prefix='set ')
+                print(format_aws_credentials(aws_credentials, prefix='set '))
             else:
-                print_aws_credentials(aws_credentials, prefix='export ')
+                print(format_aws_credentials(aws_credentials, prefix='export '))
         elif arguments['--write']:
             aws_credentials_file.write(aws_credentials)
         else:

--- a/src/main/python/afp_cli/cli.py
+++ b/src/main/python/afp_cli/cli.py
@@ -179,6 +179,11 @@ def format_aws_credentials(credentials, prefix=''):
                             for (key, value) in sorted(credentials.items())])
 
 
+def format_account_and_role_list(account_and_role_list):
+    return os.linesep.join(["{0:<20} {1}".format(account, ",".join(sorted(roles)))
+                            for account, roles in sorted(account_and_role_list.items())])
+
+
 def main():
     """Main function for script execution"""
     arguments = docopt(__doc__)
@@ -227,6 +232,6 @@ def main():
                 error("Failed to start subshell: %s" % exc)
     else:
         try:
-            federation_client.print_account_and_role_list()
+            print(format_account_and_role_list(federation_client.get_account_and_role_list()))
         except Exception as exc:
             error("Failed to get account list from AWS: %s" % exc)

--- a/src/main/python/afp_cli/cli.py
+++ b/src/main/python/afp_cli/cli.py
@@ -174,9 +174,8 @@ def main():
     except Exception as exc:
         error("Failed to load configuration: %s" % exc)
 
-    api_url = arguments['--api-url'] or config.get('api_url')
-    if api_url is None:
-        api_url = 'https://{fqdn}/afp-api/latest'.format(fqdn=get_default_afp_server())
+    api_url = arguments['--api-url'] or config.get('api_url') or \
+              'https://{fqdn}/afp-api/latest'.format(fqdn=get_default_afp_server())
     username = arguments['--user'] or config.get("user") or getpass.getuser()
     password = 'PASSWORD' if arguments['--no-ask-pw'] else get_password(username)
     federation_client = AWSFederationClientCmd(api_url=api_url,

--- a/src/main/python/afp_cli/cli.py
+++ b/src/main/python/afp_cli/cli.py
@@ -94,10 +94,10 @@ for file in /etc/bash.bashrc ~/.bashrc; do
 done
 
 function afp_minutes_left {{
-    if ((SECONDS >= {AWS_VALID_SECONDS})) ; then
+    if ((SECONDS >= {valid_seconds})) ; then
         echo EXPIRED
     else
-        echo $((({AWS_VALID_SECONDS}-SECONDS)/60)) Min
+        echo $((({valid_seconds}-SECONDS)/60)) Min
     fi
 }}
 
@@ -113,7 +113,8 @@ set PROMPT=$C AWS {account}/{role} $F
 def start_subshell(aws_credentials, role, account):
     print("Press CTRL+D to exit.")
     rc_script = tempfile.NamedTemporaryFile(mode='w')
-    rc_script.write(RC_SCRIPT_TEMPLATE.format(role=role, account=account))
+    rc_script.write(RC_SCRIPT_TEMPLATE.format(role=role, account=account,
+                                              valid_seconds=aws_credentials['AWS_VALID_SECONDS']))
     rc_script.write(cli.format_aws_credentials(aws_credentials, prefix='export '))
     rc_script.flush()
     subprocess.call(

--- a/src/main/python/afp_cli/cli_functions.py
+++ b/src/main/python/afp_cli/cli_functions.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+
+import os
+import sys
+from datetime import datetime
+
+
+def get_valid_seconds(aws_expiration_date, utcnow=datetime.utcnow()):
+    try:
+        credentials_valid_until = datetime.strptime(aws_expiration_date, "%Y-%m-%dT%H:%M:%SZ", )
+        return (credentials_valid_until - utcnow).seconds
+    except Exception:
+        default_seconds = 3600
+        msg = "Failed to parse expiration date '{0}' for AWS credentials, assuming {1} seconds.".format(
+            aws_expiration_date, default_seconds)
+        print(msg, file=sys.stderr)
+        return default_seconds
+
+
+def format_aws_credentials(credentials, prefix=''):
+    """Format aws credentials with optional prefix"""
+    return os.linesep.join(["{0}{1}='{2}'".format(prefix, key, value)
+                            for (key, value) in sorted(credentials.items())])
+
+
+def format_account_and_role_list(account_and_role_list):
+    return os.linesep.join(["{0:<20} {1}".format(account, ",".join(sorted(roles)))
+                            for account, roles in sorted(account_and_role_list.items())])

--- a/src/main/python/afp_cli/cli_functions.py
+++ b/src/main/python/afp_cli/cli_functions.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
 
+from datetime import datetime
 import os
 import sys
-from datetime import datetime
 
 
-def get_valid_seconds(aws_expiration_date, utcnow=datetime.utcnow()):
+def get_valid_seconds(aws_expiration_date, utcnow):
     try:
         credentials_valid_until = datetime.strptime(aws_expiration_date, "%Y-%m-%dT%H:%M:%SZ", )
         return (credentials_valid_until - utcnow).seconds

--- a/src/main/python/afp_cli/client.py
+++ b/src/main/python/afp_cli/client.py
@@ -7,12 +7,6 @@ import json
 from requests.auth import HTTPBasicAuth
 
 
-def print_aws_credentials(credentials, prefix=''):
-    """Print aws credentials with optional prefix"""
-    for key, value in sorted(credentials.items()):
-        print("{0}{1}='{2}'".format(prefix, key, value))
-
-
 class AWSFederationClientCmd(object):
     """Class for a command line client which uses the afp api"""
 

--- a/src/main/python/afp_cli/client.py
+++ b/src/main/python/afp_cli/client.py
@@ -49,10 +49,3 @@ class AWSFederationClientCmd(object):
                 'AWS_SESSION_TOKEN': aws_credentials['Token'],
                 'AWS_SECURITY_TOKEN': aws_credentials['Token'],
                 'AWS_EXPIRATION_DATE': aws_credentials['Expiration']}
-
-    def print_account_and_role_list(self):
-        """Print account and role list to stdout"""
-        accounts_and_roles = sorted(self.get_account_and_role_list().items())
-        for account, roles in accounts_and_roles:
-            role_string = ",".join(sorted(roles))
-            print("{0:<20} {1}".format(account, role_string))

--- a/src/main/python/afp_cli/client.py
+++ b/src/main/python/afp_cli/client.py
@@ -27,6 +27,7 @@ class AWSFederationClientCmd(object):
                                                      self._password))
         if api_result.status_code != 200:
             if api_result.status_code == 401:
+                # Need to treat 401 specially since it is directly send from webserver and body has different format.
                 raise Exception("API call to AWS (%s/%s) failed: %s %s" % (
                     self.api_url, url_suffix, api_result.status_code, api_result.reason))
             else:

--- a/src/unittest/python/aws_federation_client_cmd_tests.py
+++ b/src/unittest/python/aws_federation_client_cmd_tests.py
@@ -4,7 +4,7 @@ from __future__ import print_function, absolute_import, unicode_literals, divisi
 
 from mock import patch, Mock
 from unittest2 import TestCase
-from afp_cli import AWSFederationClientCmd, print_aws_credentials
+from afp_cli import AWSFederationClientCmd
 
 
 class AWSFederationClientCmdTest(TestCase):
@@ -53,13 +53,3 @@ class AWSFederationClientCmdTest(TestCase):
         mock_get_account_and_role_list.return_value = expected_result
         self.api_client.print_account_and_role_list()
         mock_print.assert_called_with("testaccount2         testrole1,testrole2")
-
-    @patch("six.moves.builtins.print")
-    def test_print_aws_credentials_with_export_style_with_correct_format(self, mock_print):
-        input_ = {"AWS_ACCESS_KEY_ID": "testAccessKey"}
-        print_aws_credentials(input_)
-        mock_print.assert_called_with("AWS_ACCESS_KEY_ID='testAccessKey'")
-        print_aws_credentials(input_, prefix='export ')
-        mock_print.assert_called_with("export AWS_ACCESS_KEY_ID='testAccessKey'")
-        print_aws_credentials(input_, prefix='set ')
-        mock_print.assert_called_with("set AWS_ACCESS_KEY_ID='testAccessKey'")

--- a/src/unittest/python/aws_federation_client_cmd_tests.py
+++ b/src/unittest/python/aws_federation_client_cmd_tests.py
@@ -37,4 +37,3 @@ class AWSFederationClientCmdTest(TestCase):
                                   "AWS_SECURITY_TOKEN": "testToken",
                                   "AWS_EXPIRATION_DATE": "2015-01-01T12:34:56Z"},
                          msg='Should be the same')
-

--- a/src/unittest/python/aws_federation_client_cmd_tests.py
+++ b/src/unittest/python/aws_federation_client_cmd_tests.py
@@ -38,18 +38,3 @@ class AWSFederationClientCmdTest(TestCase):
                                   "AWS_EXPIRATION_DATE": "2015-01-01T12:34:56Z"},
                          msg='Should be the same')
 
-    @patch("six.moves.builtins.print")
-    @patch("afp_cli.client.AWSFederationClientCmd.get_account_and_role_list")
-    def test_print_account_and_one_role_with_correct_format(self, mock_get_account_and_role_list, mock_print):
-        expected_result = {"testaccount1": ["testrole1"]}
-        mock_get_account_and_role_list.return_value = expected_result
-        self.api_client.print_account_and_role_list()
-        mock_print.assert_called_with("testaccount1         testrole1")
-
-    @patch("six.moves.builtins.print")
-    @patch("afp_cli.client.AWSFederationClientCmd.get_account_and_role_list")
-    def test_print_account_and_two_roles_with_correct_format(self, mock_get_account_and_role_list, mock_print):
-        expected_result = {"testaccount2": ["testrole1", "testrole2"]}
-        mock_get_account_and_role_list.return_value = expected_result
-        self.api_client.print_account_and_role_list()
-        mock_print.assert_called_with("testaccount2         testrole1,testrole2")

--- a/src/unittest/python/cli_functions_tests.py
+++ b/src/unittest/python/cli_functions_tests.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from unittest2 import TestCase
-from afp_cli import cli
+import afp_cli.cli_functions as cli
 from datetime import datetime
 
 

--- a/src/unittest/python/cli_functions_tests.py
+++ b/src/unittest/python/cli_functions_tests.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from unittest2 import TestCase
+from afp_cli import cli
+from datetime import datetime
+
+
+class CliFunctionsTest(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_format_aws_credentials_with_prefix(self):
+        credentials = {"AWS_ACCESS_KEY_ID": "testAccessKey"}
+        self.assertEqual(cli.format_aws_credentials(credentials),
+                         "AWS_ACCESS_KEY_ID='testAccessKey'")
+
+        self.assertEqual(cli.format_aws_credentials(credentials, prefix='export '),
+                         "export AWS_ACCESS_KEY_ID='testAccessKey'")
+
+        self.assertEqual(cli.format_aws_credentials(credentials, prefix='set '),
+                         "set AWS_ACCESS_KEY_ID='testAccessKey'")
+
+    def test_format_aws_credentials_multline(self):
+        input_ = {"AWS_ACCESS_KEY_ID": "testAccessKey",
+                  "AWS_SECRET_ACCESS_KEY": "not so secret"}
+
+        self.assertEqual(cli.format_aws_credentials(input_),
+                         "AWS_ACCESS_KEY_ID='testAccessKey'\nAWS_SECRET_ACCESS_KEY='not so secret'")
+
+    def test_get_valid_seconds(self):
+        self.assertEqual(cli.get_valid_seconds('2016-08-16T07:45:00Z', datetime(2016, 8, 16, hour=7, minute=15)),
+                         30*60)

--- a/src/unittest/python/cli_functions_tests.py
+++ b/src/unittest/python/cli_functions_tests.py
@@ -34,3 +34,11 @@ class CliFunctionsTest(TestCase):
     def test_get_valid_seconds(self):
         self.assertEqual(cli.get_valid_seconds('2016-08-16T07:45:00Z', datetime(2016, 8, 16, hour=7, minute=15)),
                          30*60)
+
+    def test_format_account_and_one_role(self):
+        self.assertEqual(cli.format_account_and_role_list({"testaccount1": ["testrole1"]}),
+                         "testaccount1         testrole1")
+
+    def test_format_account_and_two_roles(self):
+        self.assertEqual(cli.format_account_and_role_list({"testaccount2": ["testrole1", "testrole2"]}),
+                         "testaccount2         testrole1,testrole2")


### PR DESCRIPTION
See discussion in #20. 
Works with `--show`, with `--export`, and in subshell. Does not change `--write`.

Since the coverage check didn't like unit tests for module `cli`, I moved the tested functions to a new module.

I also hope that you like unit tests without mocks as much as I do. ;)
