### PR TITLE
Remove_Error_Exit

### DIFF
--- a/src/main/python/afp_cli/cli.py
+++ b/src/main/python/afp_cli/cli.py
@@ -80,7 +80,10 @@ def main():
         elif arguments['--write']:
             write(aws_credentials)
         else:
-            enter_subx(aws_credentials, account, role)
+            try:
+                enter_subx(aws_credentials, account, role)
+            except CMDLineExit as e:
+                error(e)
     else:
         try:
             print(format_account_and_role_list(federation_client.get_account_and_role_list()))

--- a/src/main/python/afp_cli/cli.py
+++ b/src/main/python/afp_cli/cli.py
@@ -42,6 +42,14 @@ from .password_providers import get_password
 
 
 def main():
+
+    try:
+        unprotected_main()
+    except CMDLineExit as e:
+        error(e)
+
+
+def unprotected_main():
     """Main function for script execution"""
     arguments = docopt(__doc__)
     if arguments['--debug']:
@@ -60,10 +68,7 @@ def main():
                          config.get("password-provider") or
                          'prompt')
 
-    try:
-        password = get_password(password_provider, username)
-    except CMDLineExit as e:
-        error(e)
+    password = get_password(password_provider, username)
 
     federation_client = AWSFederationClientCmd(api_url=api_url,
                                                username=username,
@@ -80,10 +85,7 @@ def main():
         elif arguments['--write']:
             write(aws_credentials)
         else:
-            try:
-                enter_subx(aws_credentials, account, role)
-            except CMDLineExit as e:
-                error(e)
+            enter_subx(aws_credentials, account, role)
     else:
         try:
             print(format_account_and_role_list(federation_client.get_account_and_role_list()))

--- a/src/main/python/afp_cli/cli_functions.py
+++ b/src/main/python/afp_cli/cli_functions.py
@@ -5,7 +5,7 @@ import random
 import socket
 import sys
 
-from .log import error
+from .log import CMDLineExit
 from .client import APICallError
 
 
@@ -32,14 +32,14 @@ def get_default_afp_server():
         addrinfos = socket.getaddrinfo("afp", 443,
                                        socket.AF_INET, socket.SOCK_STREAM)
     except Exception as exc:
-        error("Could not resolve hostname 'afp': %s" % exc)
+        raise CMDLineExit("Could not resolve hostname 'afp': %s" % exc)
     addrinfo = random.choice(addrinfos)
     afp_server_ip = addrinfo[4][0]
 
     try:
         return socket.gethostbyaddr(afp_server_ip)[0]
     except Exception as exc:
-        error("DNS reverse lookup failed for IP %s: %s" % (
+        raise CMDLineExit("DNS reverse lookup failed for IP %s: %s" % (
             afp_server_ip, exc))
 
 
@@ -48,18 +48,18 @@ def get_first_role(federation_client, account):
         accounts_and_roles = federation_client.get_account_and_role_list()
         return sorted(accounts_and_roles[account])[0]
     except APICallError as exc:
-        error("Failed to get account list from AWS: %s" % exc)
+        raise CMDLineExit("Failed to get account list from AWS: %s" % exc)
     except KeyError:
-        error("%s is not a valid AWS account" % account)
+        raise CMDLineExit("%s is not a valid AWS account" % account)
     except IndexError:
-        error("Could not find any role for account %s" % account)
+        raise CMDLineExit("Could not find any role for account %s" % account)
 
 
 def get_aws_credentials(federation_client, account, role):
     try:
         aws_credentials = federation_client.get_aws_credentials(account, role)
     except APICallError as exc:
-        error("Failed to get credentials from AWS: %s" % exc)
+        raise CMDLineExit("Failed to get credentials from AWS: %s" % exc)
     else:
         aws_credentials['AWS_VALID_SECONDS'] = get_valid_seconds(aws_credentials['AWS_EXPIRATION_DATE'],
                                                                  datetime.utcnow())

--- a/src/main/python/afp_cli/exporters.py
+++ b/src/main/python/afp_cli/exporters.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import tempfile
 
-from .log import error
+from .log import CMDLineExit
 
 RC_SCRIPT_TEMPLATE = """
 # Pretend to be an interactive, non-login shell
@@ -84,4 +84,4 @@ def enter_subx(aws_credentials, account, role):
         else:
             start_subshell(aws_credentials, account, role)
     except Exception as exc:
-        error("Failed to start subshell: %s" % exc)
+        raise CMDLineExit("Failed to start subshell: %s" % exc)

--- a/src/unittest/python/cli_functions_tests.py
+++ b/src/unittest/python/cli_functions_tests.py
@@ -3,13 +3,14 @@
 
 from unittest2 import TestCase
 from datetime import datetime
-from mock import patch, Mock, ANY
+from mock import patch, Mock
 
 from afp_cli.cli_functions import (get_valid_seconds,
                                    get_first_role,
                                    get_aws_credentials,
                                    )
 from afp_cli.client import APICallError
+from afp_cli.log import CMDLineExit
 
 
 class GetValidSecondsTest(TestCase):
@@ -47,28 +48,22 @@ class GetFirstRoleTests(TestCase):
              'ACCOUNT2': ['ROLE3', 'ROLE4']}
         self.assertEqual('ROLE1', get_first_role(client, 'ACCOUNT1'))
 
-    @patch('afp_cli.cli_functions.error')
-    def test_excpetion_when_fetching_roles(self, error_mock):
+    def test_excpetion_when_fetching_roles(self):
         client = Mock()
         client.get_account_and_role_list.side_effect = APICallError
-        get_first_role(client, 'ANY_ACCOUNT')
-        error_mock.assert_called_once_with(ANY)
+        self.assertRaises(CMDLineExit, get_first_role, client, 'ANY_ACCOUNT')
 
-    @patch('afp_cli.cli_functions.error')
-    def test_excpetion_when_looking_for_account(self, error_mock):
+    def test_excpetion_when_looking_for_account(self):
         client = Mock()
         client.get_account_and_role_list.return_value = \
             {'ACCOUNT1': ['ROLE1']}
-        get_first_role(client, 'ACCOUNT2')
-        error_mock.assert_called_once_with(ANY)
+        self.assertRaises(CMDLineExit, get_first_role, client, 'ACCOUNT2')
 
-    @patch('afp_cli.cli_functions.error')
-    def test_excpetion_when_looking_for_role(self, error_mock):
+    def test_excpetion_when_looking_for_role(self):
         client = Mock()
         client.get_account_and_role_list.return_value = \
             {'ACCOUNT1': []}
-        get_first_role(client, 'ACCOUNT1')
-        error_mock.assert_called_once_with(ANY)
+        self.assertRaises(CMDLineExit, get_first_role, client, 'ACCOUNT1')
 
 
 class GetAWSCredentialsTest(TestCase):
@@ -89,9 +84,7 @@ class GetAWSCredentialsTest(TestCase):
         received = get_aws_credentials(client, 'ACCOUNT1', 'ROLE1')
         self.assertEqual(expected, received)
 
-    @patch('afp_cli.cli_functions.error')
-    def test_excpetion(self, error_mock):
+    def test_excpetion(self):
         client = Mock()
         client.get_aws_credentials.side_effect = APICallError
-        get_aws_credentials(client, 'ACCOUNT1', 'ROLE1')
-        error_mock.assert_called_once_with(ANY)
+        self.assertRaises(CMDLineExit, get_aws_credentials, client, 'ACCOUNT1', 'ROLE1')


### PR DESCRIPTION
Remove the use of 'error' (which calls system exit) from most modules. This
should only be used in the cli.
