### PR TITLE
Replace 'subshell' with 'shell' in afpv2

### DIFF
--- a/src/cmdlinetest/test_afp_cli_v2.t
+++ b/src/cmdlinetest/test_afp_cli_v2.t
@@ -27,7 +27,7 @@
       afp [options] help
       afp [options] version
       afp [options] list
-      afp [options] (show | export | write | subshell) <accountname> [<rolename>]
+      afp [options] (show | export | write | shell) <accountname> [<rolename>]
   [1]
 
   $ afp -h
@@ -37,7 +37,7 @@
       afp [options] help
       afp [options] version
       afp [options] list
-      afp [options] (show | export | write | subshell) <accountname> [<rolename>]
+      afp [options] (show | export | write | shell) <accountname> [<rolename>]
   
   Options:
     -h, --help                          Show this.
@@ -56,7 +56,7 @@
     show                                Show credentials.
     export                              Show credentials in an export suitable format.
     write                               Write credentials to aws credentials file.
-    subshell                            Open a subshell with exported credentials.
+    shell                               Open a subshell with exported credentials.
 
   $ afp --help
   Command line client for the AFP V2 (AWS Federation Proxy)
@@ -65,7 +65,7 @@
       afp [options] help
       afp [options] version
       afp [options] list
-      afp [options] (show | export | write | subshell) <accountname> [<rolename>]
+      afp [options] (show | export | write | shell) <accountname> [<rolename>]
   
   Options:
     -h, --help                          Show this.
@@ -84,7 +84,7 @@
     show                                Show credentials.
     export                              Show credentials in an export suitable format.
     write                               Write credentials to aws credentials file.
-    subshell                            Open a subshell with exported credentials.
+    shell                               Open a subshell with exported credentials.
 
   $ afp help
   Command line client for the AFP V2 (AWS Federation Proxy)
@@ -93,7 +93,7 @@
       afp [options] help
       afp [options] version
       afp [options] list
-      afp [options] (show | export | write | subshell) <accountname> [<rolename>]
+      afp [options] (show | export | write | shell) <accountname> [<rolename>]
   
   Options:
     -h, --help                          Show this.
@@ -112,7 +112,7 @@
     show                                Show credentials.
     export                              Show credentials in an export suitable format.
     write                               Write credentials to aws credentials file.
-    subshell                            Open a subshell with exported credentials.
+    shell                               Open a subshell with exported credentials.
 
 # Test failing to access AFP
 
@@ -140,8 +140,8 @@
    u?'export': False, (re)
    u?'help': False, (re)
    u?'list': True, (re)
+   u?'shell': False, (re)
    u?'show': False, (re)
-   u?'subshell': False, (re)
    u?'version': False, (re)
    u?'write': False} (re)
   Subcommand is 'list'
@@ -165,8 +165,8 @@
    u?'export': False, (re)
    u?'help': False, (re)
    u?'list': True, (re)
+   u?'shell': False, (re)
    u?'show': False, (re)
-   u?'subshell': False, (re)
    u?'version': False, (re)
    u?'write': False} (re)
   Subcommand is 'list'
@@ -190,8 +190,8 @@
    u?'export': False, (re)
    u?'help': False, (re)
    u?'list': True, (re)
+   u?'shell': False, (re)
    u?'show': False, (re)
-   u?'subshell': False, (re)
    u?'version': False, (re)
    u?'write': False} (re)
   Subcommand is 'list'
@@ -216,7 +216,7 @@
 
 # Test credentials with subshell
 
-  $ afp -p testing -a http://localhost:5555 subshell test_account test_role < /dev/null
+  $ afp -p testing -a http://localhost:5555 shell test_account test_role < /dev/null
   Entering AFP subshell for account test_account, role test_role.
   Press CTRL+D to exit.
   Left AFP subshell.

--- a/src/main/python/afp_cli/cliv2.py
+++ b/src/main/python/afp_cli/cliv2.py
@@ -6,7 +6,7 @@ Usage:
     afp [options] help
     afp [options] version
     afp [options] list
-    afp [options] (show | export | write | subshell) <accountname> [<rolename>]
+    afp [options] (show | export | write | shell) <accountname> [<rolename>]
 
 Options:
   -h, --help                          Show this.
@@ -25,7 +25,7 @@ Subcommands:
   show                                Show credentials.
   export                              Show credentials in an export suitable format.
   write                               Write credentials to aws credentials file.
-  subshell                            Open a subshell with exported credentials.
+  shell                               Open a subshell with exported credentials.
 """  # NOQA, docopt stuff is allowed to be longcat, and longcat is loooong
 
 from __future__ import absolute_import, division, print_function
@@ -49,11 +49,11 @@ from .exporters import (enter_subx,
 from .log import CMDLineExit, debug, error, info
 from .password_providers import get_password
 
-HELP, VERSION, LIST, SHOW, EXPORT, WRITE, SUBSHELL = \
-    'help', 'version', 'list', 'show', 'export', 'write', 'subshell'
+HELP, VERSION, LIST, SHOW, EXPORT, WRITE, SHELL = \
+    'help', 'version', 'list', 'show', 'export', 'write', 'shell'
 
-SUBCOMMANDS = [HELP, VERSION, LIST, SHOW, EXPORT, WRITE, SUBSHELL]
-ASSUME_SUBCOMMANDS = [SHOW, EXPORT, WRITE, SUBSHELL]
+SUBCOMMANDS = [HELP, VERSION, LIST, SHOW, EXPORT, WRITE, SHELL]
+ASSUME_SUBCOMMANDS = [SHOW, EXPORT, WRITE, SHELL]
 
 
 def main():
@@ -122,5 +122,5 @@ def unprotected_main():
         print_export(aws_credentials)
     elif arguments['write']:
         write(aws_credentials)
-    elif arguments['subshell']:
+    elif arguments['shell']:
         enter_subx(aws_credentials, account, role)

--- a/zsh/_afp
+++ b/zsh/_afp
@@ -34,7 +34,7 @@ __afp_commands(){
         show:'Show credentials.'
         export:'Show credentials in an export suitable format.'
         write:'Write credentials to aws credentials file.'
-        subshell:'Open a subshell with exported credentials.'
+        shell:'Open a subshell with exported credentials.'
     )
     _describe -t assume_commands "assume commands" assume_commands
     _describe -t help_commands "help commands" help_commands
@@ -108,7 +108,7 @@ case $state in
     (help|version|list)
         _message 'No more arguments'
         ;;
-    (show|export|write|subshell)
+    (show|export|write|shell)
         __afp_accounts
         ;;
     esac


### PR DESCRIPTION
Review by @schlomo and to be done before #38 
