### PR TITLE
implement alternative output formats for afpv2

### DIFF
--- a/src/cmdlinetest/afp_mock.py
+++ b/src/cmdlinetest/afp_mock.py
@@ -86,7 +86,8 @@ def daemon_run(host="localhost", port="8080", pidfile=None, logfile=None):
 
 @route('/account')
 def account():
-    return """{"test_account": ["test_role"]}"""
+    return '{"test_account": ["test_role"],' \
+           '"test_account_with_long_name": ["test_role_with_long_name"]}'
 
 
 @route('/account/<account>/<role>')

--- a/src/cmdlinetest/test_afp_cli.t
+++ b/src/cmdlinetest/test_afp_cli.t
@@ -90,7 +90,8 @@
 # Test get account and role
 
   $ afp --password-provider testing --api-url=http://localhost:5555
-  test_account         test_role
+  test_account                   test_role
+  test_account_with_long_name    test_role_with_long_name
 
 # Test credentials with subshell
 

--- a/src/cmdlinetest/test_afp_cli_v2.t
+++ b/src/cmdlinetest/test_afp_cli_v2.t
@@ -26,7 +26,7 @@
   Usage:
       afp [options] help
       afp [options] version
-      afp [options] list
+      afp [options] list [--output <output_format>]
       afp [options] (show | export | write | shell) <accountname> [<rolename>]
   [1]
 
@@ -36,7 +36,7 @@
   Usage:
       afp [options] help
       afp [options] version
-      afp [options] list
+      afp [options] list [--output <output_format>]
       afp [options] (show | export | write | shell) <accountname> [<rolename>]
   
   Options:
@@ -46,6 +46,7 @@
     -s, --server <servername>           The AFP server to use.
     -a, --api-url <api-url>             The URL of the AFP server (e.g. https://afp/afp-api/latest). Takes precedence over --server.
     -p, --password-provider <provider>  Password provider. Valid values are: 'prompt', 'keyring' and 'testing'.
+    -o, --output <output_format>        Output format for 'list'. Valid values are: 'human', 'json' and 'csv'
     <accountname>                       The AWS account id you want to login to.
     <rolename>                          The AWS role you want to use for login. Defaults to the first role.
   
@@ -64,7 +65,7 @@
   Usage:
       afp [options] help
       afp [options] version
-      afp [options] list
+      afp [options] list [--output <output_format>]
       afp [options] (show | export | write | shell) <accountname> [<rolename>]
   
   Options:
@@ -74,6 +75,7 @@
     -s, --server <servername>           The AFP server to use.
     -a, --api-url <api-url>             The URL of the AFP server (e.g. https://afp/afp-api/latest). Takes precedence over --server.
     -p, --password-provider <provider>  Password provider. Valid values are: 'prompt', 'keyring' and 'testing'.
+    -o, --output <output_format>        Output format for 'list'. Valid values are: 'human', 'json' and 'csv'
     <accountname>                       The AWS account id you want to login to.
     <rolename>                          The AWS role you want to use for login. Defaults to the first role.
   
@@ -92,7 +94,7 @@
   Usage:
       afp [options] help
       afp [options] version
-      afp [options] list
+      afp [options] list [--output <output_format>]
       afp [options] (show | export | write | shell) <accountname> [<rolename>]
   
   Options:
@@ -102,6 +104,7 @@
     -s, --server <servername>           The AFP server to use.
     -a, --api-url <api-url>             The URL of the AFP server (e.g. https://afp/afp-api/latest). Takes precedence over --server.
     -p, --password-provider <provider>  Password provider. Valid values are: 'prompt', 'keyring' and 'testing'.
+    -o, --output <output_format>        Output format for 'list'. Valid values are: 'human', 'json' and 'csv'
     <accountname>                       The AWS account id you want to login to.
     <rolename>                          The AWS role you want to use for login. Defaults to the first role.
   
@@ -132,6 +135,7 @@
   {u?'--api-url': 'http://localhost:5555', (re)
    u?'--debug': True, (re)
    u?'--help': False, (re)
+   u?'--output': None, (re)
    u?'--password-provider': 'testing', (re)
    u?'--server': None, (re)
    u?'--user': None, (re)
@@ -148,6 +152,7 @@
   'api-url' is 'http://localhost:5555'
   'username' is '.*' (re)
   'password-provider' is 'testing'
+  'output' is 'human'
   [1]
 
 # Test failing to access AFP with debug and username
@@ -157,6 +162,7 @@
   {u?'--api-url': 'http://localhost:5555', (re)
    u?'--debug': True, (re)
    u?'--help': False, (re)
+   u?'--output': None, (re)
    u?'--password-provider': 'testing', (re)
    u?'--server': None, (re)
    u?'--user': 'test_user', (re)
@@ -173,6 +179,7 @@
   'api-url' is 'http://localhost:5555'
   'username' is 'test_user'
   'password-provider' is 'testing'
+  'output' is 'human'
   [1]
 
 # Test failing to access AFP with debug and username with long options
@@ -182,6 +189,7 @@
   {u?'--api-url': 'http://localhost:5555', (re)
    u?'--debug': True, (re)
    u?'--help': False, (re)
+   u?'--output': None, (re)
    u?'--password-provider': 'testing', (re)
    u?'--server': None, (re)
    u?'--user': 'test_user', (re)
@@ -198,6 +206,7 @@
   'api-url' is 'http://localhost:5555'
   'username' is 'test_user'
   'password-provider' is 'testing'
+  'output' is 'human'
   [1]
 
 # BEGIN mocking AFP
@@ -213,6 +222,20 @@
 
   $ afp -p testing -a http://localhost:5555  list
   test_account         test_role
+
+  $ afp -p testing -a http://localhost:5555  list -o human
+  test_account         test_role
+
+  $ afp -p testing -a http://localhost:5555  list -o json
+  {
+      "test_account": [
+          "test_role"
+      ]
+  }
+
+  $ afp -p testing -a http://localhost:5555  list -o csv
+  test_account,test_role
+
 
 # Test credentials with subshell
 

--- a/src/cmdlinetest/test_afp_cli_v2.t
+++ b/src/cmdlinetest/test_afp_cli_v2.t
@@ -221,20 +221,26 @@
 # Test get account and role
 
   $ afp -p testing -a http://localhost:5555  list
-  test_account         test_role
+  test_account                   test_role
+  test_account_with_long_name    test_role_with_long_name
 
   $ afp -p testing -a http://localhost:5555  list -o human
-  test_account         test_role
+  test_account                   test_role
+  test_account_with_long_name    test_role_with_long_name
 
   $ afp -p testing -a http://localhost:5555  list -o json
   {
       "test_account": [
           "test_role"
+      ],
+      "test_account_with_long_name": [
+          "test_role_with_long_name"
       ]
   }
 
   $ afp -p testing -a http://localhost:5555  list -o csv
   test_account,test_role
+  test_account_with_long_name,test_role_with_long_name
 
 
 # Test credentials with subshell

--- a/src/main/python/afp_cli/cliv2.py
+++ b/src/main/python/afp_cli/cliv2.py
@@ -5,7 +5,7 @@ Command line client for the AFP V2 (AWS Federation Proxy)
 Usage:
     afp [options] help
     afp [options] version
-    afp [options] list
+    afp [options] list [--output <output_format>]
     afp [options] (show | export | write | shell) <accountname> [<rolename>]
 
 Options:
@@ -15,6 +15,7 @@ Options:
   -s, --server <servername>           The AFP server to use.
   -a, --api-url <api-url>             The URL of the AFP server (e.g. https://afp/afp-api/latest). Takes precedence over --server.
   -p, --password-provider <provider>  Password provider. Valid values are: 'prompt', 'keyring' and 'testing'.
+  -o, --output <output_format>        Output format for 'list'. Valid values are: 'human', 'json' and 'csv'
   <accountname>                       The AWS account id you want to login to.
   <rolename>                          The AWS role you want to use for login. Defaults to the first role.
 
@@ -111,9 +112,14 @@ def unprotected_main():
         aws_credentials = get_aws_credentials(federation_client, account, role)
 
     if arguments['list']:
+
+        output_format = (arguments['--output'] or
+                         config.get("output") or
+                         'human')
+        debug("'output' is '{0}'".format(output_format))
         try:
             info(format_account_and_role_list(
-                federation_client.get_account_and_role_list()))
+                 federation_client.get_account_and_role_list(), output_format))
         except Exception as exc:
             error("Failed to get account list from AWS: %s" % exc)
     elif arguments[SHOW]:

--- a/src/main/python/afp_cli/cliv2.py
+++ b/src/main/python/afp_cli/cliv2.py
@@ -116,11 +116,11 @@ def unprotected_main():
                 federation_client.get_account_and_role_list()))
         except Exception as exc:
             error("Failed to get account list from AWS: %s" % exc)
-    elif arguments['show']:
+    elif arguments[SHOW]:
         info(format_aws_credentials(aws_credentials))
-    elif arguments['export']:
+    elif arguments[EXPORT]:
         print_export(aws_credentials)
-    elif arguments['write']:
+    elif arguments[WRITE]:
         write(aws_credentials)
-    elif arguments['shell']:
+    elif arguments[SHELL]:
         enter_subx(aws_credentials, account, role)

--- a/src/main/python/afp_cli/exporters.py
+++ b/src/main/python/afp_cli/exporters.py
@@ -46,8 +46,10 @@ def format_aws_credentials(credentials, prefix=''):
 
 def format_account_and_role_list(account_and_role_list, output_formt=HUMAN):
     if output_formt == HUMAN:
-        return os.linesep.join(["{0:<20} {1}".format(account, ",".join(sorted(roles)))
-                               for account, roles in sorted(account_and_role_list.items())])
+        padding = max([len(account) for account in account_and_role_list]) + 3
+        return os.linesep.join(
+            ["{0:<{2}} {1}".format(account, ",".join(sorted(roles)), padding)
+             for account, roles in sorted(account_and_role_list.items())])
     elif output_formt == JSON:
         return json.dumps(account_and_role_list,
                           sort_keys=True,

--- a/src/unittest/python/exporters_tests.py
+++ b/src/unittest/python/exporters_tests.py
@@ -36,15 +36,18 @@ class FormattingTest(TestCase):
                   "AWS_SECRET_ACCESS_KEY": "not so secret"}
 
         self.assertEqual(format_aws_credentials(input_),
-                         "AWS_ACCESS_KEY_ID='testAccessKey'\nAWS_SECRET_ACCESS_KEY='not so secret'")
+                         "AWS_ACCESS_KEY_ID='testAccessKey'\n"
+                         "AWS_SECRET_ACCESS_KEY='not so secret'")
 
     def test_format_account_and_one_role(self):
-        self.assertEqual(format_account_and_role_list({"testaccount1": ["testrole1"]}),
-                         "testaccount1         testrole1")
+        self.assertEqual(format_account_and_role_list(
+            {"testaccount1": ["testrole1"]}),
+            "testaccount1         testrole1")
 
     def test_format_account_and_two_roles(self):
-        self.assertEqual(format_account_and_role_list({"testaccount2": ["testrole1", "testrole2"]}),
-                         "testaccount2         testrole1,testrole2")
+        self.assertEqual(format_account_and_role_list(
+            {"testaccount2": ["testrole1", "testrole2"]}),
+            "testaccount2         testrole1,testrole2")
 
     @patch('os.name', 'unix')
     @patch('afp_cli.exporters.format_aws_credentials')

--- a/src/unittest/python/exporters_tests.py
+++ b/src/unittest/python/exporters_tests.py
@@ -42,12 +42,21 @@ class FormattingTest(TestCase):
     def test_format_account_and_one_role(self):
         self.assertEqual(format_account_and_role_list(
             {"testaccount1": ["testrole1"]}),
-            "testaccount1         testrole1")
+            "testaccount1    testrole1")
 
     def test_format_account_and_two_roles(self):
         self.assertEqual(format_account_and_role_list(
             {"testaccount2": ["testrole1", "testrole2"]}),
-            "testaccount2         testrole1,testrole2")
+            "testaccount2    testrole1,testrole2")
+
+    def test_format_two_accounts(self):
+        self.assertEqual(format_account_and_role_list(
+            {"testaccount":                ["testrole1"],
+             "testaccount_with_long_name": ["testrole2"]
+             }),
+            "testaccount                   testrole1\n"
+            "testaccount_with_long_name    testrole2"
+            )
 
     @patch('os.name', 'unix')
     @patch('afp_cli.exporters.format_aws_credentials')


### PR DESCRIPTION
More advanced output options for afpv2: support both json and csv for
processing accounts lists programmatically.
