### PR TITLE
Simple call mode for afpv2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/src/cmdlinetest/test_afp_cli_v2.t
+++ b/src/cmdlinetest/test_afp_cli_v2.t
@@ -49,6 +49,8 @@
     -a, --api-url <api-url>             The URL of the AFP server (e.g. https://afp/afp-api/latest). Takes precedence over --server.
     -p, --password-provider <provider>  Password provider. Valid values are: 'prompt', 'keyring' and 'testing'.
     -o, --output <output_format>        Output format for 'list'. Valid values are: 'human', 'json' and 'csv'
+  
+  Arguments:
     <accountname>                       The AWS account id you want to login to.
     <rolename>                          The AWS role you want to use for login. Defaults to the first role.
   
@@ -79,6 +81,8 @@
     -a, --api-url <api-url>             The URL of the AFP server (e.g. https://afp/afp-api/latest). Takes precedence over --server.
     -p, --password-provider <provider>  Password provider. Valid values are: 'prompt', 'keyring' and 'testing'.
     -o, --output <output_format>        Output format for 'list'. Valid values are: 'human', 'json' and 'csv'
+  
+  Arguments:
     <accountname>                       The AWS account id you want to login to.
     <rolename>                          The AWS role you want to use for login. Defaults to the first role.
   
@@ -109,6 +113,8 @@
     -a, --api-url <api-url>             The URL of the AFP server (e.g. https://afp/afp-api/latest). Takes precedence over --server.
     -p, --password-provider <provider>  Password provider. Valid values are: 'prompt', 'keyring' and 'testing'.
     -o, --output <output_format>        Output format for 'list'. Valid values are: 'human', 'json' and 'csv'
+  
+  Arguments:
     <accountname>                       The AWS account id you want to login to.
     <rolename>                          The AWS role you want to use for login. Defaults to the first role.
   

--- a/src/cmdlinetest/test_afp_cli_v2.t
+++ b/src/cmdlinetest/test_afp_cli_v2.t
@@ -28,6 +28,7 @@
       afp [options] version
       afp [options] list [--output <output_format>]
       afp [options] (show | export | write | shell) <accountname> [<rolename>]
+      afp [options] <accountname> [<rolename>]
   [1]
 
   $ afp -h
@@ -38,6 +39,7 @@
       afp [options] version
       afp [options] list [--output <output_format>]
       afp [options] (show | export | write | shell) <accountname> [<rolename>]
+      afp [options] <accountname> [<rolename>]
   
   Options:
     -h, --help                          Show this.
@@ -67,6 +69,7 @@
       afp [options] version
       afp [options] list [--output <output_format>]
       afp [options] (show | export | write | shell) <accountname> [<rolename>]
+      afp [options] <accountname> [<rolename>]
   
   Options:
     -h, --help                          Show this.
@@ -96,6 +99,7 @@
       afp [options] version
       afp [options] list [--output <output_format>]
       afp [options] (show | export | write | shell) <accountname> [<rolename>]
+      afp [options] <accountname> [<rolename>]
   
   Options:
     -h, --help                          Show this.
@@ -250,6 +254,12 @@
   Press CTRL+D to exit.
   Left AFP subshell.
 
+# Test credentials with simple call mode
+
+  $ afp -p testing -a http://localhost:5555 test_account test_role < /dev/null
+  Entering AFP subshell for account test_account, role test_role.
+  Press CTRL+D to exit.
+  Left AFP subshell.
 
 # Test credentials with show
 

--- a/src/main/python/afp_cli/cliv2.py
+++ b/src/main/python/afp_cli/cliv2.py
@@ -7,6 +7,7 @@ Usage:
     afp [options] version
     afp [options] list [--output <output_format>]
     afp [options] (show | export | write | shell) <accountname> [<rolename>]
+    afp [options] <accountname> [<rolename>]
 
 Options:
   -h, --help                          Show this.
@@ -50,11 +51,11 @@ from .exporters import (enter_subx,
 from .log import CMDLineExit, debug, error, info
 from .password_providers import get_password
 
-HELP, VERSION, LIST, SHOW, EXPORT, WRITE, SHELL = \
-    'help', 'version', 'list', 'show', 'export', 'write', 'shell'
+HELP, VERSION, LIST, SHOW, EXPORT, WRITE, SHELL, SIMPLE = \
+    'help', 'version', 'list', 'show', 'export', 'write', 'shell', 'simple'
 
 SUBCOMMANDS = [HELP, VERSION, LIST, SHOW, EXPORT, WRITE, SHELL]
-ASSUME_SUBCOMMANDS = [SHOW, EXPORT, WRITE, SHELL]
+ASSUME_SUBCOMMANDS = [SHOW, EXPORT, WRITE, SHELL, SIMPLE]
 
 
 def main():
@@ -71,8 +72,9 @@ def unprotected_main():
         log.DEBUG = True
     debug(arguments)
 
-    # parse the subcommand, only one will be active
-    subcommand = [s for s in SUBCOMMANDS if arguments[s]][0]
+    # parse the subcommand, use SIMPLE mode if no subcommand
+    subcommand = [s for s in SUBCOMMANDS if arguments[s]]
+    subcommand = subcommand[0] if subcommand else SIMPLE
     debug("Subcommand is '{0}'".format(subcommand))
 
     if subcommand == VERSION:
@@ -129,4 +131,6 @@ def unprotected_main():
     elif arguments[WRITE]:
         write(aws_credentials)
     elif arguments[SHELL]:
+        enter_subx(aws_credentials, account, role)
+    elif subcommand == SIMPLE:
         enter_subx(aws_credentials, account, role)

--- a/src/main/python/afp_cli/cliv2.py
+++ b/src/main/python/afp_cli/cliv2.py
@@ -67,6 +67,11 @@ def main():
         error(e)
 
 
+def _get_first(list_, default=None):
+    """ Return the first item if list is non-empty and default otherwise. """
+    return list_[0] if list_ else default
+
+
 def unprotected_main():
     """Main function for script execution"""
     arguments = docopt(__doc__)
@@ -75,8 +80,7 @@ def unprotected_main():
     debug(arguments)
 
     # parse the subcommand, use SIMPLE mode if no subcommand
-    subcommand = [s for s in SUBCOMMANDS if arguments[s]]
-    subcommand = subcommand[0] if subcommand else SIMPLE
+    subcommand = _get_first([s for s in SUBCOMMANDS if arguments[s]], SIMPLE)
     debug("Subcommand is '{0}'".format(subcommand))
 
     if subcommand == VERSION:

--- a/src/main/python/afp_cli/cliv2.py
+++ b/src/main/python/afp_cli/cliv2.py
@@ -119,7 +119,7 @@ def unprotected_main():
             get_first_role(federation_client, account)
         aws_credentials = get_aws_credentials(federation_client, account, role)
 
-    if arguments[LIST]:
+    if subcommand == LIST:
 
         output_format = (arguments['--output'] or
                          config.get("output") or
@@ -130,13 +130,13 @@ def unprotected_main():
                  federation_client.get_account_and_role_list(), output_format))
         except Exception as exc:
             error("Failed to get account list from AWS: %s" % exc)
-    elif arguments[SHOW]:
+    elif subcommand == SHOW:
         info(format_aws_credentials(aws_credentials))
-    elif arguments[EXPORT]:
+    elif subcommand == EXPORT:
         print_export(aws_credentials)
-    elif arguments[WRITE]:
+    elif subcommand == WRITE:
         write(aws_credentials)
-    elif arguments[SHELL]:
+    elif subcommand == SHELL:
         enter_subx(aws_credentials, account, role)
     elif subcommand == SIMPLE:
         enter_subx(aws_credentials, account, role)

--- a/src/main/python/afp_cli/cliv2.py
+++ b/src/main/python/afp_cli/cliv2.py
@@ -17,6 +17,8 @@ Options:
   -a, --api-url <api-url>             The URL of the AFP server (e.g. https://afp/afp-api/latest). Takes precedence over --server.
   -p, --password-provider <provider>  Password provider. Valid values are: 'prompt', 'keyring' and 'testing'.
   -o, --output <output_format>        Output format for 'list'. Valid values are: 'human', 'json' and 'csv'
+
+Arguments:
   <accountname>                       The AWS account id you want to login to.
   <rolename>                          The AWS role you want to use for login. Defaults to the first role.
 


### PR DESCRIPTION
Let's have a shortcut for the most common use case. If I enter `afpv2 <something>` and `<something>` is not one of help, version or list then simply do a `afpv2 shell <something>`.

IMHO this is the most common use case (at least for me it covers about 99.99% of my AFP uses) and actually this shortcut is already part of the v1 CLI.
