### PR TITLE
report that credentials have been written

### DIFF
--- a/src/cmdlinetest/test_afp_cli.t
+++ b/src/cmdlinetest/test_afp_cli.t
@@ -141,6 +141,7 @@
 
   $ export HOME=$CRAMTMP
   $ afp --password-provider testing --api-url=http://localhost:5555 --write test_account test_role
+  Wrote credentials to file: '/tmp/cramtests-.*/\.aws/credentials' (re)
   $ cat $HOME/.aws/credentials
   [default]
   aws_access_key_id = XXXXXXXXXXXX

--- a/src/cmdlinetest/test_afp_cli_v2.t
+++ b/src/cmdlinetest/test_afp_cli_v2.t
@@ -290,6 +290,7 @@
 # Test write credentials to file
 
   $ afp -p testing -a http://localhost:5555 write test_account test_role
+  Wrote credentials to file: '/tmp/cramtests-.*/\.aws/credentials' (re)
   $ cat $HOME/.aws/credentials
   [default]
   aws_access_key_id = XXXXXXXXXXXX
@@ -300,6 +301,7 @@
 # Test that an unicode role name doesn't break the commandline
 
   $ afp -p testing -a http://localhost:5555 write test_account test_rolé
+  Wrote credentials to file: '/tmp/cramtests-.*/\.aws/credentials' (re)
 
 # Output version of self
 

--- a/src/main/python/afp_cli/aws_credentials_file.py
+++ b/src/main/python/afp_cli/aws_credentials_file.py
@@ -3,6 +3,7 @@ from six.moves import configparser
 from afp_cli.compat import OrderedDict
 import os
 import six
+from .log import info
 
 
 def write(aws_credentials, filename=None, profile_name='default'):
@@ -38,6 +39,7 @@ def write(aws_credentials, filename=None, profile_name='default'):
 
         with open(filename, 'w') as config_file:
             config.write(config_file)
+        info("Wrote credentials to file: '{0}'".format(filename))
 
     finally:
         if six.PY2:


### PR DESCRIPTION
This was discovered recently, someone I was woring with used `write` and then
wondered where the credentials had been written. This should fix that.
