### PR TITLE
Improve reusability of get_api_url()

### DIFF
--- a/src/main/python/afp_cli/cli_functions.py
+++ b/src/main/python/afp_cli/cli_functions.py
@@ -55,16 +55,18 @@ def sanitize_host(server_name):
             afp_server_ip, exc))
 
 
-def get_api_url(arguments, config):
+def get_api_url(arguments=None, config=None):
     """
     Return a calculated/sanitized API URL from config and/or command
     line parameters.
     """
-    passed_api_url = arguments['--api-url'] or config.get('api_url')
+    arguments = arguments or {}
+    config = config or {}
+    passed_api_url = arguments.get('--api-url') or config.get('api_url')
     if passed_api_url is not None:
         # No checks whatsoever, just return the preferred API URL
         return passed_api_url
-    server_name = arguments['--server'] or config.get('server') or 'afp'
+    server_name = arguments.get('--server') or config.get('server') or 'afp'
     sanitized_server_name = sanitize_host(server_name)
     return 'https://{fqdn}/afp-api/latest'.format(fqdn=sanitized_server_name)
 

--- a/src/unittest/python/cli_functions_tests.py
+++ b/src/unittest/python/cli_functions_tests.py
@@ -192,6 +192,17 @@ class GetApiUrlTest(TestCase):
         self.assertEqual(result, 'https://FQDN/afp-api/latest')
         self.mock_sanitize_host.assert_called_once_with('afp')
 
+    def test_easily_reusable(self):
+        """To be reusable in external tools, it should not require parameters
+
+        Especially the 'arguments' parameter is a docopt-specific
+        implementation detail and must not be mandatory.
+        """
+        result = get_api_url()
+
+        self.assertEqual(result, 'https://FQDN/afp-api/latest')
+        self.mock_sanitize_host.assert_called_once_with('afp')
+
 
 class SanitizeHostTest(TestCase):
     """


### PR DESCRIPTION
When external tools want to use the AWSFederationClientCmd class, they need to know the api_url. However, the get_api_url() function makes it difficult to just get the default api_url since it expects to be given a doctopt-style data structure.

This patch makes it possible to get the default api_url by simply not specifying any parameters.
