### PR TITLE
persist cookies on disk

### DIFF
--- a/src/main/python/afp_cli/client.py
+++ b/src/main/python/afp_cli/client.py
@@ -34,7 +34,7 @@ class AWSFederationClientCmd(object):
         self.user_config_dir = os.path.expanduser("~/.afp-cli")
         self.cookie_filepath = os.path.join(self.user_config_dir, 'cookies')
         if os.path.exists(self.cookie_filepath):
-            cookies = pickle.load(open(self.cookie_filepath))
+            cookies = pickle.load(open(self.cookie_filepath, 'rb'))
             self.session.cookies = cookies
 
     def call_api(self, url_suffix):
@@ -56,7 +56,7 @@ class AWSFederationClientCmd(object):
                     url_orig, api_result.json()['message']))
         if not os.path.exists(self.user_config_dir):
             os.mkdir(self.user_config_dir)
-        pickle.dump(self.session.cookies, open(self.cookie_filepath, 'w'))
+        pickle.dump(self.session.cookies, open(self.cookie_filepath, 'wb'))
         return api_result.text
 
     def get_account_and_role_list(self):

--- a/src/main/python/afp_cli/client.py
+++ b/src/main/python/afp_cli/client.py
@@ -10,6 +10,7 @@ from requests.auth import HTTPBasicAuth
 from six.moves.urllib.parse import quote
 from six import PY3
 
+
 class APICallError(Exception):
     def __str__(self, *args, **kwargs):
         if PY3:

--- a/src/unittest/python/aws_federation_client_cmd_tests.py
+++ b/src/unittest/python/aws_federation_client_cmd_tests.py
@@ -11,18 +11,16 @@ class AWSFederationClientCmdTest(TestCase):
     def setUp(self):
         self.api_client = AWSFederationClientCmd()
 
-    @patch("afp_cli.client.requests.get")
-    def test_get_correct_account_and_role_list(self, mock_get):
+    def test_get_correct_account_and_role_list(self):
         expected_result = Mock(text='{"testaccount": ["testrole"]}',
                                status_code=200,
                                reason="Ok")
-        mock_get.return_value = expected_result
-        result = self.api_client.get_account_and_role_list()
-        self.assertEqual(
-            result, {"testaccount": ["testrole"]}, msg='Should be the same')
+        with patch.object(self.api_client.session, 'get', return_value=expected_result):
+            result = self.api_client.get_account_and_role_list()
+            self.assertEqual(
+                result, {"testaccount": ["testrole"]}, msg='Should be the same')
 
-    @patch("afp_cli.client.requests.get")
-    def test_get_correct_aws_credentials(self, mock_get):
+    def test_get_correct_aws_credentials(self):
         expected_result = Mock(
             text='{"Code": "Success", '
             '"AccessKeyId": "testAccessKey", '
@@ -31,12 +29,12 @@ class AWSFederationClientCmdTest(TestCase):
             '"Expiration": "2015-01-01T12:34:56Z"}',
             status_code=200,
             reason="Ok")
-        mock_get.return_value = expected_result
-        result = self.api_client.get_aws_credentials("testaccount", "testrole")
-        self.assertEqual(result, {
-            "AWS_ACCESS_KEY_ID": "testAccessKey",
-            "AWS_SECRET_ACCESS_KEY": "testSecretAccessKey",
-            "AWS_SESSION_TOKEN": "testToken",
-            "AWS_SECURITY_TOKEN": "testToken",
-            "AWS_EXPIRATION_DATE": "2015-01-01T12:34:56Z"},
-            msg='Should be the same')
+        with patch.object(self.api_client.session, 'get', return_value=expected_result):
+            result = self.api_client.get_aws_credentials("testaccount", "testrole")
+            self.assertEqual(result, {
+                "AWS_ACCESS_KEY_ID": "testAccessKey",
+                "AWS_SECRET_ACCESS_KEY": "testSecretAccessKey",
+                "AWS_SESSION_TOKEN": "testToken",
+                "AWS_SECURITY_TOKEN": "testToken",
+                "AWS_EXPIRATION_DATE": "2015-01-01T12:34:56Z"},
+                msg='Should be the same')


### PR DESCRIPTION
This is in order to make afp-cli work with Sticky sessions enabled on the ALB.